### PR TITLE
chore: Update virtualbox-guest-additions-iso to 7.0.20-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+virtualbox-guest-additions-iso (7.0.20-1) unstable; urgency=medium
+
+  * New upstream version 7.0.20
+
+ -- Gianfranco Costamagna <locutusofborg@debian.org>  Tue, 16 Jul 2024 15:00:30 +0200
+
 virtualbox-guest-additions-iso (7.0.18-1) unstable; urgency=medium
 
   * New upstream version 7.0.18


### PR DESCRIPTION
Link: http://deb.debian.org/debian/pool/non-free/v/virtualbox-guest-additions-iso/virtualbox-guest-additions-iso_7.0.20.orig.tar.xz
Link: http://deb.debian.org/debian/pool/non-free/v/virtualbox-guest-additions-iso/virtualbox-guest-additions-iso_7.0.20-1.debian.tar.xz